### PR TITLE
type : permit `strings` to be used as identifiers for types

### DIFF
--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -525,13 +525,13 @@ defmodule Absinthe.Schema do
   List all implementors of an interface on a schema
   """
   @spec implementors(t, Type.identifier_t | Type.Interface.t) :: [Type.Object.t]
-  def implementors(schema, ident) when is_atom(ident) do
+  def implementors(schema, %Type.Interface{} = iface) do
+    implementors(schema, iface.__reference__.identifier)
+  end
+  def implementors(schema, ident) do
     schema.__absinthe_interface_implementors__
     |> Map.get(ident, [])
     |> Enum.map(&lookup_type(schema, &1))
-  end
-  def implementors(schema, %Type.Interface{} = iface) do
-    implementors(schema, iface.__reference__.identifier)
   end
 
   @doc false

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1507,15 +1507,26 @@ defmodule Absinthe.Schema.Notation do
   end
 
   # Find the name, or default as necessary
-  defp default_name(identifier, nil, opts) do
-    if opts[:title] do
-      identifier |> Atom.to_string |> Utils.camelize
-    else
-      identifier |> Atom.to_string
-    end
+  defp default_name(identifier, nil, opts) when is_atom(identifier) do
+    identifier
+    |> Atom.to_string
+    |> camelize_identifier(opts)
   end
+
+  defp default_name("" <> identifier, nil, opts) do
+    identifier |> camelize_identifier(opts)
+  end
+
   defp default_name(_, name, _) do
     name
+  end
+
+  defp camelize_identifier(identifier, opts) do
+    if opts[:title] do
+      identifier |> Utils.camelize
+    else
+      identifier
+    end
   end
 
   @doc false

--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -17,7 +17,7 @@ defmodule Absinthe.Type do
   @type t :: custom_t | wrapping_t
 
   @typedoc "A type identifier"
-  @type identifier_t :: atom
+  @type identifier_t :: atom | String.t
 
   @typedoc "A type reference"
   @type reference_t :: identifier_t | t
@@ -252,6 +252,10 @@ defmodule Absinthe.Type do
   def expand(ref, schema) when is_atom(ref) do
     schema.__absinthe_lookup__(ref)
   end
+  @doc "Expand any string type references inside a List or NonNull"
+  def expand("" <> ref, schema) do
+    schema.__absinthe_lookup__(ref)
+  end
   def expand(%{of_type: contents} = ref, schema) do
     %{ref | of_type: expand(contents, schema)}
   end
@@ -396,8 +400,7 @@ defmodule Absinthe.Type do
       |> Enum.reduce(acc, &referenced_types(&1, schema, &2))
     end
   end
-  defp referenced_types(type, schema, acc) when is_atom(type) and type != nil do
+  defp referenced_types(type, schema, acc) when type != nil do
     referenced_types(Schema.lookup_type(schema, type), schema, acc)
   end
-
 end

--- a/test/lib/absinthe/schema_test.exs
+++ b/test/lib/absinthe/schema_test.exs
@@ -153,6 +153,10 @@ defmodule Absinthe.SchemaTest do
       field :name, :string
     end
 
+    object "buzz" do
+      field :name, :string
+    end
+
   end
 
   test "can have a description on the root query" do
@@ -178,6 +182,10 @@ defmodule Absinthe.SchemaTest do
 
     test "is supported" do
       assert "Foo" == Schema.lookup_type(ThirdSchema, :foo).name
+    end
+
+    test "is supported for string identifiers" do
+      assert "Buzz" == Schema.lookup_type(ThirdSchema, "buzz").name
     end
 
   end

--- a/test/lib/absinthe/type_test.exs
+++ b/test/lib/absinthe/type_test.exs
@@ -49,6 +49,12 @@ defmodule Absinthe.TypeTest do
       field :authors, list_of(:author)
     end
 
+    object "animal" do
+      description "A Basic Type with a string identifier"
+
+      field :id, :id
+      field :name, :string
+    end
   end
 
   test "definition with custom name" do
@@ -57,6 +63,10 @@ defmodule Absinthe.TypeTest do
 
   test "that uses a name derived from the identifier" do
     assert %Type.Object{name: "Item"} = BasicSchema.__absinthe_type__(:item)
+  end
+
+  test "that uses a name derived from a string identifier" do
+    assert %Type.Object{name: "Animal"} = BasicSchema.__absinthe_type__("animal")
   end
 
   test "root query type definition" do


### PR DESCRIPTION
**Context**

For types which are dynamically generated at runtime the use of an `atom`
as an identifier is not suitable as it could eventually lead to exhausting
the `atom` table limit, resulting in an application crash.

**Changes**

- referenced_type lookups are no-longer restricted to `atoms`
- type expansions extended to support `strings` lookups for `lists`
- updated schema notation to support string identifiers

**Ref**

* [#439](https://github.com/absinthe-graphql/absinthe/issues/439)

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
